### PR TITLE
Bug 977082 - Scratchpad [ Pretty Print ] should not insert space between...

### DIFF
--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -340,7 +340,8 @@
       if (ltt == ")" && (token.type.type != ")"
                          && token.type.type != "]"
                          && token.type.type != ";"
-                         && token.type.type != ",")) {
+                         && token.type.type != ","
+                         && token.type.type != ".")) {
         return true;
       }
     }

--- a/test.js
+++ b/test.js
@@ -481,6 +481,18 @@ var testCases = [
     output: "'\\0'\n"
   },
 
+  {
+    name: "Bug 977082 - space between grouping operator and dot notation",
+    input: "JSON.stringify(3).length;\n" +
+           "([1,2,3]).length;\n" +
+           "(new Date()).toLocaleString();\n",
+    output: "JSON.stringify(3).length;\n" +
+            "([1,\n" +
+            "2,\n" +
+            "3]).length;\n" +
+            "(new Date()).toLocaleString();\n"
+  }
+
 ];
 
 var sourceMap = this.sourceMap || require("source-map");


### PR DESCRIPTION
... grouping operator and dot notation. r=fitzgen

This is the upstream fix for reviewed https://bugzilla.mozilla.org/show_bug.cgi?id=977082
