### PR TITLE
eslint checks syntax/jsdoc, jscs checks style. Run them via scripts chan...

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "globals": {
+    "describe"   : false,
+    "it"         : false,
+    // "before"     : false,
+    // "beforeEach" : false,
+    // "after"      : false,
+    // "afterEach"  : false
+  },
+  "rules": {
+    "eqeqeq": 0,
+    "curly": 0,
+    "quotes": [ 2, "double", "avoid-escape" ],
+    "valid-jsdoc": 1,
+    "no-use-before-define": 1,
+    "no-underscore-dangle": 1,
+    "no-extend-native": 1
+  }
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,28 @@
+{
+  "validateIndentation":2,
+  // JSHint: "indent": 2,
+  "disallowMixedSpacesAndTabs":true,
+  // JSHint: "smarttabs":false,
+  "maximumLineLength":80,
+  // JSHint: "maxlen": 80,
+  "disallowTrailingWhitespace": true,
+  // JSHint: "trailing": true,
+  "requireCurlyBraces": [],
+  // JSHint: "curly": false,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInNamedFunctionExpression": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInNamedFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningCurlyBrace": true,
+    "beforeOpeningRoundBrace": true
+  }
+  // , "validateJSDoc": {
+  //   "checkParamNames": true,
+  //   "checkRedundantParams": true
+  //   // "requireParamTypes": true
+  // }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
   - "0.10"
+

--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
   "license": "BSD",
   "main": "pretty-fast.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "eslint -f compact *.js; jscs --reporter inline *.js; node test.js"
   },
   "bin": {
     "pretty-fast": "./bin/pretty-fast"
   },
   "repository": "",
+  "devDependencies": {
+    "eslint": "0.6.2",
+    "jscs": "1.4.5"
+  },
   "dependencies": {
     "source-map": "~0.1.30",
     "acorn": "~0.4.2",


### PR DESCRIPTION
...ge.

Here is a thought to employ eslint for syntax and jdoc3 checking.

ESLint has the nice feature to easily switch a rule from a warning to an error and vice versa.

jscs is useful since ESLint (like jshint as of v2.5.0) does not check for coding style like indentation, trailing or embedded whitespace. It's also highly configurable, so my config choices are just a start, mostly in line with my recent work in
https://github.com/mdn/addon-sdk-content-scripts/pull/2
and
https://github.com/mdn/addon-sdk-content-scripts/pull/3

I'm curious how you like this.

Adrian
