### PR TITLE
Updated source-map dependency to 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-fast",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A fast JavaScript pretty printer.",
   "author": "Nick Fitzgerald <fitzgen@gmail.com>",
   "homepage": "https://github.com/mozilla/pretty-fast",
@@ -22,7 +22,7 @@
     "eslint": "0.6.2"
   },
   "dependencies": {
-    "source-map": "~0.1.30",
+    "source-map": "^0.5.6",
     "acorn": "~2.6.4",
     "optimist": "~0.6.0"
   }


### PR DESCRIPTION
Updating source-map to latest version to fix compatibility with webpack 3. This is required to land webpack 3 support in debugger.html