### PR TITLE
Fix let and const issues with spacing

### DIFF
--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -355,6 +355,10 @@
       if (lastToken.value == "let") {
         return true;
       }
+
+      if (lastToken.value == "const") {
+        return true;
+      }
     }
 
     if (token.type.isAssign) {

--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -351,6 +351,10 @@
                          && token.type.label != ".")) {
         return true;
       }
+
+      if (lastToken.value == "let") {
+        return true;
+      }
     }
 
     if (token.type.isAssign) {

--- a/test.js
+++ b/test.js
@@ -527,8 +527,18 @@ var testCases = [
             "    // don't respond if you don't understand the message.\n" +
             "    return;\n" +
             "}\n"
-  }
+  },
 
+  {
+    name: "Let handling without value",
+    input: "let d;\n",
+    output: "let d;\n"
+  },
+  {
+    name: "Let handling with value",
+    input: "let d = 'yes';\n",
+    output: "let d = 'yes';\n"
+  }
 ];
 
 var sourceMap = this.sourceMap || require("source-map");

--- a/test.js
+++ b/test.js
@@ -528,7 +528,11 @@ var testCases = [
             "    return;\n" +
             "}\n"
   },
-
+  {
+    name: "Const handling",
+    input: "const d = 'yes';\n",
+    output: "const d = 'yes';\n"
+  },
   {
     name: "Let handling without value",
     input: "let d;\n",


### PR DESCRIPTION
There's a decent chance this is too simplistic but I discovered with debugger.html (https://github.com/devtools-html/debugger.html/issues/3552) that the following caused a problem with pretty print:

```js
// Before pretty-print
let d;
// After
letd;
```

