### PR TITLE
add template literals -Bump acorn to 5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-fast",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A fast JavaScript pretty printer.",
   "author": "Nick Fitzgerald <fitzgen@gmail.com>",
   "homepage": "https://github.com/mozilla/pretty-fast",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "source-map": "^0.5.7",
-    "acorn": "~2.6.4",
+    "acorn": "~5.2.1",
     "optimist": "~0.6.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -512,7 +512,7 @@ var testCases = [
            "    console.warn('unknown request'); //$NON-NLS-0$\n" +
            "    // don't respond if you don't understand the message.\n" +
            "    return;\n" +
-           "}\n",
+           "}\n" ,
     output: "switch (request.action) {\n" +
             "  case 'show': //$NON-NLS-0$\n" +
             "    if (localStorage.hideicon !== 'true') { //$NON-NLS-0$\n" +
@@ -542,6 +542,15 @@ var testCases = [
     name: "Let handling with value",
     input: "let d = 'yes';\n",
     output: "let d = 'yes';\n"
+  },
+  {
+    name: "Template literals",
+    input: "\`${JSON.stringify({class: 'testing'})}\`",
+    output: "\`${JSON.stringify({\n" +
+            "  class : 'testing'\n" +
+    "})\n" +
+    "}\n" +
+    "\`\n"
   }
 ];
 


### PR DESCRIPTION
- Bump acron to 5.2.1 - mainly due to https://github.com/ternjs/acorn/issues/575
- Added new test for template literals