### PR TITLE
Fix dot notation

### DIFF
--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -333,7 +333,8 @@
       }
 
       var ltk = lastToken.type.keyword;
-      if (ltk != null) {
+      var ttl = token.type.label;
+      if (ltk != null && ttl != ".") {
         if (ltk == "break" || ltk == "continue" || ltk == "return") {
           return token.type.label != ";";
         }
@@ -352,14 +353,6 @@
                          && token.type.label != ";"
                          && token.type.label != ","
                          && token.type.label != ".")) {
-        return true;
-      }
-
-      if (lastToken.value == "let") {
-        return true;
-      }
-
-      if (lastToken.value == "const") {
         return true;
       }
 
@@ -456,7 +449,7 @@
       spaceAdded = true;
     }
 
-    if (lastToken && ltt != "}" && ttk == "else") {
+    if (lastToken && ltt != "}" && ltt != "." && ttk == "else") {
       write(" ",
             lastToken.loc.start.line,
             lastToken.loc.start.column);

--- a/test.js
+++ b/test.js
@@ -678,6 +678,16 @@ var testCases = [
     output: "foo.a = 1.1;\n" +
             "foo.do.switch.case.default = 2.2;\n" +
             "foo.b = 3.3;\n"
+  },
+  {
+    name: "Dot handling with let which is identifier name",
+    input: "y.let.let = 1.23;\n",
+    output: "y.let.let = 1.23;\n"
+  },
+  {
+    name: "Dot handling with keywords which are identifier name",
+    input: "y.await.break.const.delete.else.return.new.yield = 1.23;\n",
+    output: "y.await.break.const.delete.else.return.new.yield = 1.23;\n"
   }
 ];
 


### PR DESCRIPTION
Dot notation with identifier name(keywords, let) don't need whitespace.

Test case 1

Before:
```
y.let .let = 1.23;
```
After:
```
y.let.let = 123;
```
Test case 2

Before:
```
y.await.break .const .delete . else .return .new .yield = 1.23;
```
After:
```
y.await.break.const.delete.else.return.new.yield = 1.23;
```