### PR TITLE
Fix two indentation problems

### DIFF
--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -851,6 +851,11 @@
       }
 
       ttk = token.type.keyword;
+
+      if (ttk && lastToken && lastToken.type.label == ".") {
+        token.type = acorn.tokTypes.name;
+      }
+
       ttl = token.type.label;
 
       if (ttl == "eof") {

--- a/test.js
+++ b/test.js
@@ -671,6 +671,13 @@ var testCases = [
     name: "Bug pretty-sure-9 - accept unary operator at start of file",
     input: "+ 0",
     output: "+ 0\n"
+  },
+  {
+    name: "Stack-keyword property access",
+    input: "foo.a=1.1;foo.do.switch.case.default=2.2;foo.b=3.3;\n",
+    output: "foo.a = 1.1;\n" +
+            "foo.do.switch.case.default = 2.2;\n" +
+            "foo.b = 3.3;\n"
   }
 ];
 


### PR DESCRIPTION
### 1
Accessing property names which have the same name as keywords that belong on the stack adds these keyword tokens to the stack and possibly increases indentation. The stack/indentation level is not accordingly decremented since the property access is not actually a block and doesn't have the matching end-token. For example,
```js
foo.a=1.1;foo.switch=2.2;foo.b=3.3;
```
becomes
```js
foo.a = 1.1;
foo.switch = 2.2;
  foo.b = 3.3;
```
I fixed this by changing `token.type` to `acorn.tokTypes.name` when a token with a keyword type comes after a dot token.

### 2 (Edit: fixed by #23)
The if-statement responsible for popping `switch` from the stack compared `token` itself to `}` rather than `token.type.label` (`ttl`). This could result in incorrect indentation in some cases, such as
```js
var foo=[function(){switch(1){}}];
```
becoming
```js
var foo = [
  function () {
    switch (1) {
    }
  }
  ];

```