### PR TITLE
Bug 1614192: Template-literal/string indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "BSD",
   "main": "pretty-fast.js",
   "scripts": {
-    "eslint": "eslint -f compact *.js",
+    "eslint": "eslint -f compact pretty-fast.js",
     "test": "npm run eslint && node test.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "BSD",
   "main": "pretty-fast.js",
   "scripts": {
-    "eslint": "eslint -f compact pretty-fast.js",
+    "eslint": "eslint -f compact *.js",
     "test": "npm run eslint && node test.js"
   },
   "bin": {

--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -325,6 +325,9 @@
       if (ltt == ";") {
         return true;
       }
+      if (ltt == "${") {
+        return true;
+      }
       if (ltt == "num" && token.type.label == ".") {
         return true;
       }
@@ -436,7 +439,9 @@
                  ttl != ";" &&
                  ttl != "," &&
                  ttl != ")" &&
-                 ttl != ".") {
+                 ttl != "." &&
+                 ttl != "template" &&
+                 ttl != "`") {
         write("\n",
               lastToken.loc.start.line,
               lastToken.loc.start.column);
@@ -444,7 +449,7 @@
       }
     }
 
-    if (ttl == ":" && stack[stack.length - 1] == "?") {
+    if ((ttl == ":" && stack[stack.length - 1] == "?") || (ttl == "}" && stack[stack.length - 1] == "${")) {
       write(" ",
             lastToken.loc.start.line,
             lastToken.loc.start.column);
@@ -591,6 +596,7 @@
       || ttl == "("
       || ttl == "["
       || ttl == "?"
+      || ttl == "${"
       || ttk == "do"
       || ttk == "switch"
       || ttk == "case"
@@ -616,7 +622,7 @@
    * indent level.
    */
   function decrementsIndent(tokenType, stack) {
-    return tokenType == "}"
+    return (tokenType == "}" && stack[stack.length - 1] != "${")
       || (tokenType == "]" && stack[stack.length - 1] == "[\n");
   }
 

--- a/test.js
+++ b/test.js
@@ -545,12 +545,14 @@ var testCases = [
   },
   {
     name: "Template literals",
-    input: "\`${JSON.stringify({class: 'testing'})}\`",
-    output: "\`${JSON.stringify({\n" +
-            "  class : 'testing'\n" +
-    "})\n" +
-    "}\n" +
-    "\`\n"
+    // issue in acorn
+    input: "\`abc${JSON.stringify({clas: 'testing'})}def\`;{a();}",
+    output: "\`abc${ JSON.stringify({\n" +
+        "  clas: 'testing'\n" +
+        "}) }def`;\n" +
+        "{\n" +
+        "  a();\n" +
+        "}\n",
   },
 
   {


### PR DESCRIPTION
This PR aims to fix the indentation problems after Template-Strings.
It formats
```js
`abc${JSON.stringify({clas: 'testing'})}def`;{a();}
```
like this:
```js
`abc${ JSON.stringify({
 clas: 'testing'
}) }def`;
{
  a();
}

```
*Note: I changed `class` to `clas` as it would cause acorn fo fail, except it being valid JS*