### PR TITLE
Fix: eslint - double-quotes

### DIFF
--- a/test.js
+++ b/test.js
@@ -354,7 +354,7 @@ const cases = [
 const sourceMap = this.sourceMap || require("source-map");
 const includesOnly = cases.find(({only}) => only);
 
-let output = ``
+let output = ""
 
 for (const {name, input, only, skip} of cases) {
   if (includesOnly && !only || skip) {


### PR DESCRIPTION
CI currently fails due to this: 
```
> pretty-fast@0.2.3 eslint /home/circleci/project
> eslint -f compact *.js
 
/home/circleci/project/test.js: line 357, col 14, Error - Strings must use doublequote. (quotes
```