### PR TITLE
Update acorn to support parsing expression with private fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ instances, and source maps in general.)
 * `indent` - The string that you want your code indented by. Most people want
   one of `"  "`, `"    "`, or `"\t"`.
 
+* `ecmaVersion` - Indicates the ECMAScript version to parse. 
+   See acorn.parse documentation for more details. Defaults to `"latest"`.
+
 ## Issues
 
 [Please use Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox&component=Developer%20Tools%3A%20Debugger)

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -804,6 +804,17 @@ Array [
 ]
 `;
 
+exports[`Optional chaining parsing support 1`] = `
+"x?.y?.z?.['a']?.check();
+"
+`;
+
+exports[`Optional chaining parsing support 2`] = `
+Array [
+  "(1, 0) -> (1, 0)",
+]
+`;
+
 exports[`Regexp 1`] = `
 "var r = /foobar/g;
 "

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -815,6 +815,33 @@ Array [
 ]
 `;
 
+exports[`Private fields parsing support 1`] = `
+"class MyClass {
+  constructor(a) {
+    this.a = a;
+  }
+  a
+  getA() {
+    return this.a;
+  }
+}
+"
+`;
+
+exports[`Private fields parsing support 2`] = `
+Array [
+  "(2, 6) -> (1, 0)",
+  "(3, 8) -> (2, 0)",
+  "(4, 10) -> (3, 0)",
+  "(5, 8) -> (4, 0)",
+  "(6, 8) -> (5, 0)",
+  "(7, 8) -> (6, 0)",
+  "(8, 10) -> (7, 0)",
+  "(9, 8) -> (8, 0)",
+  "(10, 6) -> (9, 0)",
+]
+`;
+
 exports[`Regexp 1`] = `
 "var r = /foobar/g;
 "

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-fast",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -839,9 +839,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
-      "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ=="
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
+      "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg=="
     },
     "acorn-globals": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "source-map": "^0.5.7",
-    "acorn": "~8.0.4",
+    "acorn": "~8.2.4",
     "optimist": "~0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-fast",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A fast JavaScript pretty printer.",
   "author": "Nick Fitzgerald <fitzgen@gmail.com>",
   "homepage": "https://github.com/mozilla/pretty-fast",

--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -806,6 +806,7 @@
     var tokens = acorn.tokenizer(input, {
       locations: true,
       sourceFile: options.url,
+      ecmaVersion: options.ecmaVersion || "latest",
       onComment: function (block, text, start, end, startLoc, endLoc) {
         tokenQueue.push({
           type: {},

--- a/test.js
+++ b/test.js
@@ -348,6 +348,10 @@ const cases = [
   {
     name: "Dot handling with keywords which are identifier name",
     input: "y.await.break.const.delete.else.return.new.yield = 1.23;\n",
+  },
+  {
+    name: "Optional chaining parsing support",
+    input: "x?.y?.z?.['a']?.check();\n",
   }
 ];
 

--- a/test.js
+++ b/test.js
@@ -352,6 +352,20 @@ const cases = [
   {
     name: "Optional chaining parsing support",
     input: "x?.y?.z?.['a']?.check();\n",
+  },
+  {
+    name: "Private fields parsing support",
+    input: `
+      class MyClass {
+        constructor(a) {
+          this.#a = a;
+        }
+        #a
+        #getA() {
+          return this.#a;
+        }
+      }
+    `,
   }
 ];
 


### PR DESCRIPTION
This PR has a few commits:
- add an ecmaVersion option, and default to `"latest"`. We were already having a warning when using prettyFast as the option is needed by acorn (but was defaulting to `2020`), so this fixes the warning. Furthermore, in order to parse expression with new syntax, we need to be on the latest ecmaVersion.
- Add a test case for expression with optional chaining, that should have be done when adding support for it
- Update acorn so we can get support for private fields