### PR TITLE
Directly require acorn instead of a specific file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-fast",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A fast JavaScript pretty printer.",
   "author": "Nick Fitzgerald <fitzgen@gmail.com>",
   "homepage": "https://github.com/mozilla/pretty-fast",

--- a/pretty-fast.js
+++ b/pretty-fast.js
@@ -17,7 +17,7 @@
 }(this, function () {
   "use strict";
 
-  var acorn = this.acorn || require("acorn/dist/acorn");
+  var acorn = this.acorn || require("acorn");
   var sourceMap = this.sourceMap || require("source-map");
   var SourceNode = sourceMap.SourceNode;
 


### PR DESCRIPTION
For some reason this weird require is making some mozilla-central debugger test fail when using node 12+.
Since acorn already points to the file in dist, there's no reason we don't require the whole package.

The package version is bumped so we can update it on npm